### PR TITLE
Fix search results bug

### DIFF
--- a/Weather/View/PickLocationView.swift
+++ b/Weather/View/PickLocationView.swift
@@ -87,6 +87,11 @@ struct PickLocationView: View {
                 .padding(.horizontal, 22)
             }
         }
+        .onChange(of: viewModel.searchText) {
+            if viewModel.searchText.isEmpty {
+                viewModel.searchResults.removeAll()
+            }
+        }
         .onAppear {
             Task {
                 await viewModel.loadWeatherDataForEachCity()


### PR DESCRIPTION
Added `onChange` modifier to monitor `searchText` and clear `searchResult` when `searchText.isEmpty`.
When there are no search results, display the saved city data; else, display search results. 